### PR TITLE
Unit Tests: created test_class_generator.py and test_relation_generator.py files

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""All the tests"""

--- a/tests/test_class_generator.py
+++ b/tests/test_class_generator.py
@@ -1,0 +1,76 @@
+import pytest
+
+from pygraft.class_generator import ClassGenerator
+
+class TestClassGenerator:
+    @classmethod
+    def setup_class(cls):
+        # Common setup for all test methods
+        cls.generator = ClassGenerator(
+            num_classes=20,
+            max_hierarchy_depth=5,
+            avg_class_depth=2.5,
+            class_inheritance_ratio=0.6,
+            avg_disjointness=0.2,
+            verbose=False,
+        )
+
+    def test_generate_classes(self):
+        self.generator.generate_classes()
+        assert len(self.generator.classes) == 20
+        assert all(isinstance(class_name, str) for class_name in self.generator.classes)
+
+    def test_link_child2parent(self):
+        self.generator.link_child2parent("Child1", "Parent", layer=2)
+        assert self.generator.class2subclasses_direct.get("Parent") == ["Child1"]
+        assert self.generator.class2superclass_direct.get("Child1") == "Parent"
+        assert "Child1" in self.generator.layer2classes[2]
+
+    def test_generate_class_hierarchy(self):
+        self.generator.generate_class_hierarchy()
+        assert len(self.generator.layer2classes) <= 5  # Max hierarchy depth
+        assert len(self.generator.classes) == 20  # Number of classes
+
+    def test_generate_class_disjointness(self):
+        self.generator.generate_class_disjointness()
+        assert len(self.generator.disjointwith) > 0
+        assert len(self.generator.mutual_disjointness) > 0
+
+    def test_generate_class_schema(self):
+        class_info = self.generator.generate_class_schema()
+        assert "num_classes" in class_info
+        assert "classes" in class_info
+        assert "hierarchy_depth" in class_info
+        assert "avg_class_depth" in class_info
+        assert "class_inheritance_ratio" in class_info
+        assert "direct_class2subclasses" in class_info
+        assert "direct_class2superclass" in class_info
+        assert "transitive_class2subclasses" in class_info
+        assert "transitive_class2superclasses" in class_info
+        assert "avg_class_disjointness" in class_info
+        assert "class2disjoints" in class_info
+        assert "class2disjoints_symmetric" in class_info
+        assert "class2disjoints_extended" in class_info
+        assert "layer2classes" in class_info
+        assert "class2layer" in class_info
+
+    def test_assemble_class_info(self):
+        class_info = self.generator.assemble_class_info()
+        assert "num_classes" in class_info
+        assert "classes" in class_info
+        assert "hierarchy_depth" in class_info
+        assert "avg_class_depth" in class_info
+        assert "class_inheritance_ratio" in class_info
+        assert "direct_class2subclasses" in class_info
+        assert "direct_class2superclass" in class_info
+        assert "transitive_class2subclasses" in class_info
+        assert "transitive_class2superclasses" in class_info
+        assert "avg_class_disjointness" in class_info
+        assert "class2disjoints" in class_info
+        assert "class2disjoints_symmetric" in class_info
+        assert "class2disjoints_extended" in class_info
+        assert "layer2classes" in class_info
+        assert "class2layer" in class_info
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_relation_generator.py
+++ b/tests/test_relation_generator.py
@@ -1,0 +1,94 @@
+import pytest
+from pygraft.relation_generator import RelationGenerator
+
+class TestRelationGenerator:
+    @classmethod
+    def setup_class(cls):
+        # Common setup for all test methods
+        cls.relation_generator = RelationGenerator(
+            class_info={},
+            num_relations=20,
+            relation_specificity=0.6,
+            prop_profiled_relations=0.5,
+            profile_side="both",
+            verbose=False,
+            prop_symmetric_relations=0.2,
+            prop_inverse_relations=0.1,
+            prop_functional_relations=0.3,
+            prop_inverse_functional_relations=0.1,
+            prop_transitive_relations=0.2,
+            prop_subproperties=0.1,
+            prop_reflexive_relations=0.1,
+            prop_irreflexive_relations=0.1,
+            prop_asymmetric_relations=0.1
+        )
+
+    def test_init(self):
+        assert self.relation_generator.class_info == {}
+        assert self.relation_generator.num_relations == 20
+        assert self.relation_generator.relation_specificity == 0.6
+        assert self.relation_generator.prop_profiled_relations == 0.5
+        assert self.relation_generator.profile_side == "both"
+        assert self.relation_generator.verbose is False
+        assert self.relation_generator.prop_symmetric_relations == 0.2
+        assert self.relation_generator.prop_inverse_relations == 0.1
+        assert self.relation_generator.prop_functional_relations == 0.3
+        assert self.relation_generator.prop_inverse_functional_relations == 0.1
+        assert self.relation_generator.prop_transitive_relations == 0.2
+        assert self.relation_generator.prop_subproperties == 0.1
+        assert self.relation_generator.prop_reflexive_relations == 0.1
+        assert self.relation_generator.prop_irreflexive_relations == 0.1
+        assert self.relation_generator.prop_asymmetric_relations == 0.1
+
+    def test_assemble_relation_info(self):
+        relation_info = self.relation_generator.assemble_relation_info()
+        assert "statistics" in relation_info
+        assert "relations" in relation_info
+        assert "rel2patterns" in relation_info
+        assert "pattern2rels" in relation_info
+
+        # Add more specific assertions for the assembled information
+        statistics = relation_info["statistics"]
+        assert "num_relations" in statistics
+        assert "prop_reflexive" in statistics
+        assert "prop_irreflexive" in statistics
+        assert "prop_functional" in statistics
+        assert "prop_inversefunctional" in statistics
+        assert "prop_symmetric" in statistics
+        assert "prop_asymmetric" in statistics
+        assert "prop_transitive" in statistics
+        assert "prop_inverseof" in statistics
+        assert "prop_subpropertyof" in statistics
+        assert "prop_profiled_relations" in statistics
+        assert "relation_specificity" in statistics
+
+    def test_generate_relations(self):
+        self.relation_generator.generate_relations()
+
+        # Add assertions to check if relations and properties are generated correctly
+        assert len(self.relation_generator.relations) == 20
+
+    def test_calculate_relation_specificity(self):
+        specificity = self.relation_generator.calculate_relation_specificity()
+        assert isinstance(specificity, float)
+        # Add more specific assertions for relation specificity calculation
+
+    
+    def test_calculate_profile_ratio(self):
+        # Test when profile_side is "both"
+        ratio_both = self.relation_generator.calculate_profile_ratio()
+        assert ratio_both >= 0.0 and ratio_both <= 1.0
+
+        # Test when profile_side is "source"
+        self.relation_generator.profile_side = "source"
+        ratio_source = self.relation_generator.calculate_profile_ratio()
+        assert ratio_source >= 0.0 and ratio_source <= 1.0
+
+        # Test when profile_side is "target"
+        self.relation_generator.profile_side = "target"
+        ratio_target = self.relation_generator.calculate_profile_ratio()
+        assert ratio_target >= 0.0 and ratio_target <= 1.0
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
ClassGenerator class unit tests are almost done but have one problem with `RecursionError`

RelationGenerator class has some problems with attributes not defined inside class initialization (we may add them with default values)

image of functions with errors
![image](https://github.com/nicolas-hbt/pygraft/assets/43929183/7c4125aa-e88c-4e65-95fb-cf2d2c37abe5)
